### PR TITLE
Added support for comma separated scan names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug that missed a few records in the final exported file.
+
+## [0.1.2] - 2025-12-09
+
+### Added
+
+- Support for comma separated values in the `scan_name` field of the configuration file to allow exporting multiple scans in a single run.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Users can create the following types of aggregated scan exports.
 2. `JSON` - A single JSON file will be created in the same directory of the script you write.
 3. `Parquet` - A single Apache Parquet file will be created in the same directory of the script you write.
 4. `Write to DB` - The result of the export will be written to an external database
-    - Users need to provide database credentials to a real DB, and the results of the exports are dumped into it. The
-      database needs to be created by the user before using this library. A table will be automatically created.
-    - > ⚠️ **Disclaimer**
-      Make sure the columns stay the same each time you use this export option. If the schema changes between exports,
-      the library will raise an error.
+   - Users need to provide database credentials to a real DB, and the results of the exports are dumped into it. The
+     database needs to be created by the user before using this library. A table will be automatically created.
+   - > ⚠️ **Disclaimer**
+     Make sure the columns stay the same each time you use this export option. If the schema changes between exports,
+     the library will raise an error.
 
 ## How to use this library.
 
@@ -55,8 +55,7 @@ Below is a detailed overview of the supported configuration options available in
 
 #### Config
 
-1. `scan_name` (str) Scan Name to export. A case-insensitive contains check will be run on this value. This is a *
-   *mandatory** field.
+1. `scan_name` (str) A comma-separated list of scan names to export. A case-insensitive 'contains' check will be performed for each name. This is a **mandatory** field.
 2. `allowed_memory_gb` (int) Allowed memory for the Duck DB process on the client. This is a **mandatory** field.
 3. `workers` (int) Parallelism for running exports. Defaults to 1. This value should be between 1 and 10.
 4. `window` (`Window`) Window to export scans.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tvm_multi_scan_exporter"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python library to aggregate Scan Exports into a single export"
 authors = [
     { name = "Tenable, Inc." },

--- a/src/tvm_multi_scan_exporter/scan_fetcher.py
+++ b/src/tvm_multi_scan_exporter/scan_fetcher.py
@@ -26,7 +26,7 @@ class ScansFetcher:
             # get all scans that match the `contains` name criteria
             all_matching_scans: List[Scan] = self._scans_by_name(config)
             logging.info(
-                f"{len(all_matching_scans)} scan(s) matched the scan_names filter {config.scan_name}.")
+                f"{len(all_matching_scans)} scan(s) matched the scan_name filter {config.scan_name}.")
 
             # if there are scans, look for histories.
             if all_matching_scans:

--- a/src/tvm_multi_scan_exporter/scan_fetcher.py
+++ b/src/tvm_multi_scan_exporter/scan_fetcher.py
@@ -26,7 +26,7 @@ class ScansFetcher:
             # get all scans that match the `contains` name criteria
             all_matching_scans: List[Scan] = self._scans_by_name(config)
             logging.info(
-                f"{len(all_matching_scans)} scan(s) matched the scan_name filter {config.scan_name}.")
+                f"{len(all_matching_scans)} scan(s) matched the scan_names filter {config.scan_name}.")
 
             # if there are scans, look for histories.
             if all_matching_scans:
@@ -45,16 +45,22 @@ class ScansFetcher:
         Gets all the scans by name. This applies a case-insensitive `contains` check.
         :return:
         """
-        return [
-            Scan(
-                uuid=scan.get("uuid", None),
-                name=scan["name"],
-                schedule_uuid=scan["schedule_uuid"],
-                id=scan.get("id", scan["id"])
-            )
-            for scan in self._tio.scans.list()
-            if config.scan_name.lower() in scan["name"].lower()
-        ]
+        scan_names = [name.strip().lower() for name in config.scan_name.split(',')]
+        matched_scans: List[Scan] = []
+        for scan in self._tio.scans.list():
+            scan_name_lower = scan["name"].lower()
+            matched_term = next((name for name in scan_names if name and name in scan_name_lower), None)
+            if matched_term is not None:
+                logging.info(f"Matched scan '{scan['name']}' (id={scan.get('id')}) using filter term '{matched_term}'.")
+                matched_scans.append(
+                    Scan(
+                        uuid=scan.get("uuid", None),
+                        name=scan["name"],
+                        schedule_uuid=scan["schedule_uuid"],
+                        id=scan.get("id", scan["id"])
+                    )
+                )
+        return matched_scans
 
     def _histories_for_scan(self, scan: Scan, config: Config) -> List[ScanHistory]:
         """

--- a/tests/test_scan_fetcher.py
+++ b/tests/test_scan_fetcher.py
@@ -95,3 +95,53 @@ def test_histories_with_no_matching_histories(mock_tio):
     histories = fetcher.scan_histories(config)
 
     assert len(histories) == 0
+
+
+@patch("tvm_multi_scan_exporter.scan_fetcher.TenableIO")
+def test_scans_by_name_with_multiple_comma_separated_names(mock_tio):
+    # Mock TenableIO
+    mock_tio.scans.list.return_value = [
+        {"uuid": "uuid1", "name": "First Scan", "schedule_uuid": "sched1", "id": 1},
+        {"uuid": "uuid2", "name": "Second Scan", "schedule_uuid": "sched2", "id": 2},
+        {"uuid": "uuid3", "name": "Third Scan", "schedule_uuid": "sched3", "id": 3},
+    ]
+    config = Config(scan_name="First,Third", allowed_memory_gb=2)
+
+    fetcher = ScansFetcher(mock_tio)
+    scans = fetcher._scans_by_name(config)
+
+    assert len(scans) == 2
+    assert Scan(uuid="uuid1", name="First Scan", schedule_uuid="sched1", id=1) in scans
+    assert Scan(uuid="uuid3", name="Third Scan", schedule_uuid="sched3", id=3) in scans
+
+
+@patch("tvm_multi_scan_exporter.scan_fetcher.TenableIO")
+def test_scans_by_name_with_whitespace_and_case_insensitivity(mock_tio):
+    # Mock TenableIO
+    mock_tio.scans.list.return_value = [
+        {"uuid": "uuid1", "name": "Test Scan 1", "schedule_uuid": "sched1", "id": 1},
+        {"uuid": "uuid2", "name": "Another Scan", "schedule_uuid": "sched2", "id": 2},
+    ]
+    config = Config(scan_name="  test scan  ,  ANOTHER SCAN  ", allowed_memory_gb=2)
+
+    fetcher = ScansFetcher(mock_tio)
+    scans = fetcher._scans_by_name(config)
+
+    assert len(scans) == 2
+    assert Scan(uuid="uuid1", name="Test Scan 1", schedule_uuid="sched1", id=1) in scans
+    assert Scan(uuid="uuid2", name="Another Scan", schedule_uuid="sched2", id=2) in scans
+
+
+@patch("tvm_multi_scan_exporter.scan_fetcher.TenableIO")
+def test_scans_by_name_no_matches(mock_tio):
+    # Mock TenableIO
+    mock_tio.scans.list.return_value = [
+        {"uuid": "uuid1", "name": "Test Scan 1", "schedule_uuid": "sched1", "id": 1},
+    ]
+    config = Config(scan_name="NonExistent, Other", allowed_memory_gb=2)
+
+    fetcher = ScansFetcher(mock_tio)
+    scans = fetcher._scans_by_name(config)
+
+    assert len(scans) == 0
+


### PR DESCRIPTION
# Description

This PR include support for providing `scan_name` as comma separated list of scans.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Povided single scan name (Existing case)
- [ ] Provided multiple scan names as comma separated

**Test Configuration**:
* Python Version(s) Tested:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
